### PR TITLE
Ignore results folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/build/
 __pycache__/
 *.pyc
 *.pyo
+
+# Simulation output
+results/


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude `results/` directory

## Testing
- `pytest -q`
- `python -m unittest discover -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68643583ce848323b227bf90afbffb79