### PR TITLE
Update solver settings

### DIFF
--- a/examples/FVM/HeatDiffusion/setup_1D.yaml
+++ b/examples/FVM/HeatDiffusion/setup_1D.yaml
@@ -38,7 +38,8 @@ simulation:
           value: 500
 
   solver:
-    method: "bicgstab"
+    module: "petsc"
+    method: "gmres"
     tolerance: 1e-8
     maxIterations: 1000
     preconditioner: "jacobi"


### PR DESCRIPTION
## Summary
- use PETSc GMRES solver in 1D example

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686438833f0483239cd5fe083a862682